### PR TITLE
Add database example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,14 @@ future.
 
 The main entity is called `drbd-pair`, this provisions a pair of DRBD nodes. You can then use `nodeSpecification`
 and `initialNodeSpecification` to specify an `entitySpec` containing the blueprints you want on the nodes. An
-example of this is shown in [drbd.tomcat-example.bom](drbd.tomcat-example.bom). Finally `propagatingList` allows
-you to specify a list of sensors which will be propagated back to the entity root.
+example of this is shown in [drbd.tomcat-example.bom](drbd.tomcat-example.bom). Finally `propagatingSensor` allows
+you to specify a sensor which will be propagated back to the entity root.
 
 ```
 services:
 - type: drbd-pair
   brooklyn.config:
-    propagatingList:
-    - $brooklyn:sensor("main.uri")
+    propagatingSensor: $brooklyn:sensor("main.uri")
     nodeSpecification: 
       $brooklyn:entitySpec:
         - type: example-app

--- a/drbd.bom
+++ b/drbd.bom
@@ -74,6 +74,7 @@ brooklyn.catalog:
       brooklyn.enrichers:
         - type: org.apache.brooklyn.enricher.stock.Propagator
           brooklyn.config:
+            enricher.suppressDuplicates: true
             producer: $brooklyn:parent().parent()
             propagating:
             - $brooklyn:sensor("drbd.monitor.hostaddresses")
@@ -84,6 +85,7 @@ brooklyn.catalog:
         
         - type: org.apache.brooklyn.enricher.stock.Transformer
           brooklyn.config:
+            enricher.suppressDuplicates: true
             enricher.triggerSensors:
                 - $brooklyn:sensor("is.primary")
                 - $brooklyn:sensor("service.isUp")
@@ -91,6 +93,7 @@ brooklyn.catalog:
             enricher.targetValue: $brooklyn:formatString("%s%s", $brooklyn:attributeWhenReady("is.primary"), $brooklyn:attributeWhenReady("service.isUp"))    
         - type: org.apache.brooklyn.enricher.stock.Transformer
           brooklyn.config:
+            enricher.suppressDuplicates: true
             enricher.sourceSensor: $brooklyn:sensor("primary.isUp")
             enricher.targetSensor: $brooklyn:sensor("is.active.primary")
             enricher.transformation:
@@ -99,7 +102,7 @@ brooklyn.catalog:
                factoryMethod.name: "forMap"
                factoryMethod.args:
                - "truetrue" : true
-               - false   
+               - false
                
       brooklyn.initializers:
       - type: org.apache.brooklyn.core.effector.ssh.SshCommandEffector      
@@ -442,12 +445,7 @@ brooklyn.catalog:
           entityFailed.stabilizationDelay: 30s
       - type: org.apache.brooklyn.enricher.stock.Propagator
         brooklyn.config:
-          producer: $brooklyn:child("drbd-node")
-          propagating:
-          - $brooklyn:sensor("started")
-          - $brooklyn:sensor("is.active.primary")
-      - type: org.apache.brooklyn.enricher.stock.Propagator
-        brooklyn.config:
+          enricher.suppressDuplicates: true
           producer: $brooklyn:child("drbd-node")
           propagating:
           - $brooklyn:sensor("started")
@@ -455,6 +453,7 @@ brooklyn.catalog:
           
       - type: org.apache.brooklyn.enricher.stock.Aggregator
         brooklyn.config:
+          enricher.suppressDuplicates: true
           uniqueTag: hostaddress-aggregator
           enricher.producer: $brooklyn:child("user-nodes")
           enricher.sourceSensor: $brooklyn:sensor($brooklyn:config("propagatingSensor"))
@@ -463,12 +462,14 @@ brooklyn.catalog:
           enricher.aggregator.excludeBlank: true
       - type: org.apache.brooklyn.enricher.stock.Joiner
         brooklyn.config:
+          enricher.suppressDuplicates: true
           uniqueTag: hostaddress-joiner
           enricher.sourceSensor: $brooklyn:sensor("propagatingSensor.list")
           enricher.targetSensor: $brooklyn:sensor("propagatingSensor.value")
           enricher.joiner.quote: false
       - type: org.apache.brooklyn.enricher.stock.Transformer
         brooklyn.config:
+          enricher.suppressDuplicates: true
           enricher.triggerSensors:
           - $brooklyn:sensor("is.active.primary")
           - $brooklyn:sensor("propagatingSensor.value")
@@ -563,12 +564,14 @@ brooklyn.catalog:
             enricher.targetSensor: $brooklyn:sensor("propagatingSensor.list")
             enricher.aggregating.fromMembers: true
             enricher.aggregator.excludeBlank: true
+            enricher.suppressDuplicates: true
         - type: org.apache.brooklyn.enricher.stock.Joiner
           brooklyn.config:
             uniqueTag: drbd-propagatingSensor-joiner
             enricher.sourceSensor: $brooklyn:sensor("propagatingSensor.list")
             enricher.targetSensor: $brooklyn:sensor($brooklyn:config("propagatingSensor"))
             enricher.joiner.quote: false
+            enricher.suppressDuplicates: true
         # DRBD node management
         - type: org.apache.brooklyn.enricher.stock.Aggregator
           brooklyn.config:
@@ -577,12 +580,14 @@ brooklyn.catalog:
             enricher.targetSensor: $brooklyn:sensor("drbd.monitor.hostaddress.list")
             enricher.aggregating.fromMembers: true
             enricher.aggregator.excludeBlank: true
+            enricher.suppressDuplicates: true
         - type: org.apache.brooklyn.enricher.stock.Joiner
           brooklyn.config:
             uniqueTag: drbd-hostaddress-joiner
             enricher.sourceSensor: $brooklyn:sensor("drbd.monitor.hostaddress.list")
             enricher.targetSensor: $brooklyn:sensor("drbd.monitor.hostaddresses")
             enricher.joiner.quote: false
+            enricher.suppressDuplicates: true
         - type: org.apache.brooklyn.enricher.stock.Aggregator
           brooklyn.config:
             uniqueTag: drbd-hostname-aggregator
@@ -590,12 +595,14 @@ brooklyn.catalog:
             enricher.targetSensor: $brooklyn:sensor("drbd.monitor.hostname.list")
             enricher.aggregating.fromMembers: true
             enricher.aggregator.excludeBlank: true
+            enricher.suppressDuplicates: true
         - type: org.apache.brooklyn.enricher.stock.Joiner
           brooklyn.config:
             uniqueTag: drbd-hostname-joiner
             enricher.sourceSensor: $brooklyn:sensor("drbd.monitor.hostname.list")
             enricher.targetSensor: $brooklyn:sensor("drbd.monitor.hostnames")
             enricher.joiner.quote: false
+            enricher.suppressDuplicates: true
         - type: org.apache.brooklyn.enricher.stock.Aggregator
           brooklyn.config:
             uniqueTag: drbd-isUp-aggregator
@@ -609,6 +616,7 @@ brooklyn.catalog:
             enricher.sourceSensor: $brooklyn:sensor("drbd.isUp.list")
             enricher.targetSensor: $brooklyn:sensor("drbd.isUps")
             enricher.joiner.quote: false
+            enricher.suppressDuplicates: true
         - type: org.apache.brooklyn.enricher.stock.Aggregator
           brooklyn.config:
             uniqueTag: drbd-started-aggregator
@@ -616,14 +624,17 @@ brooklyn.catalog:
             enricher.targetSensor: $brooklyn:sensor("drbd.started.list")
             enricher.aggregating.fromMembers: true
             enricher.aggregator.excludeBlank: true
+            enricher.suppressDuplicates: true
         - type: org.apache.brooklyn.enricher.stock.Joiner
           brooklyn.config:
             uniqueTag: drbd-started-joiner
             enricher.sourceSensor: $brooklyn:sensor("drbd.started.list")
             enricher.targetSensor: $brooklyn:sensor("drbd.started")
             enricher.joiner.quote: false
+            enricher.suppressDuplicates: true
         - type: org.apache.brooklyn.enricher.stock.Transformer
           brooklyn.config:
+            enricher.suppressDuplicates: true
             enricher.sourceSensor: $brooklyn:sensor("drbd.started")
             enricher.targetSensor: $brooklyn:sensor("drbd.all.started")
             enricher.transformation:

--- a/drbd.bom
+++ b/drbd.bom
@@ -98,8 +98,8 @@ brooklyn.catalog:
                type: "com.google.guava:com.google.common.base.Functions"
                factoryMethod.name: "forMap"
                factoryMethod.args:
-               - { "truetrue" : "true" }
-               - "false"    
+               - "truetrue" : true
+               - false   
                
       brooklyn.initializers:
       - type: org.apache.brooklyn.core.effector.ssh.SshCommandEffector      
@@ -446,20 +446,42 @@ brooklyn.catalog:
           propagating:
           - $brooklyn:sensor("started")
           - $brooklyn:sensor("is.active.primary")
+      - type: org.apache.brooklyn.enricher.stock.Propagator
+        brooklyn.config:
+          producer: $brooklyn:child("drbd-node")
+          propagating:
+          - $brooklyn:sensor("started")
+          - $brooklyn:sensor("is.active.primary")
+          
       - type: org.apache.brooklyn.enricher.stock.Aggregator
         brooklyn.config:
           uniqueTag: hostaddress-aggregator
           enricher.producer: $brooklyn:child("user-nodes")
-          enricher.sourceSensor: $brooklyn:sensor("main.uri")
-          enricher.targetSensor: $brooklyn:sensor("main.uri.list")
+          enricher.sourceSensor: $brooklyn:sensor($brooklyn:config("propagatingSensor"))
+          enricher.targetSensor: $brooklyn:sensor("propagatingSensor.list")
           enricher.aggregating.fromMembers: true
           enricher.aggregator.excludeBlank: true
       - type: org.apache.brooklyn.enricher.stock.Joiner
         brooklyn.config:
           uniqueTag: hostaddress-joiner
-          enricher.sourceSensor: $brooklyn:sensor("main.uri.list")
-          enricher.targetSensor: $brooklyn:sensor("main.uri")
+          enricher.sourceSensor: $brooklyn:sensor("propagatingSensor.list")
+          enricher.targetSensor: $brooklyn:sensor("propagatingSensor.value")
           enricher.joiner.quote: false
+      - type: org.apache.brooklyn.enricher.stock.Transformer
+        brooklyn.config:
+          enricher.triggerSensors:
+          - $brooklyn:sensor("is.active.primary")
+          - $brooklyn:sensor("propagatingSensor.value")
+          enricher.sourceSensor: $brooklyn:sensor("is.active.primary")
+          enricher.targetSensor: $brooklyn:sensor($brooklyn:config("propagatingSensor"))
+          enricher.transformation:
+           $brooklyn:object:
+             type: "com.google.guava:com.google.common.base.Functions"
+             factoryMethod.name: "forMap"
+             factoryMethod.args:
+             - true: $brooklyn:attributeWhenReady("propagatingSensor.value")
+             - null
+  
       brooklyn.children:
         - type: drbd-node
         - type: cluster
@@ -533,6 +555,21 @@ brooklyn.catalog:
               nodeSpecification: $brooklyn:parent().config("nodeSpecification")
       
       brooklyn.enrichers:
+        # propagating sensor
+        - type: org.apache.brooklyn.enricher.stock.Aggregator
+          brooklyn.config:
+            uniqueTag: drbd-propagatingSensor-aggregator
+            enricher.sourceSensor: $brooklyn:sensor($brooklyn:config("propagatingSensor"))
+            enricher.targetSensor: $brooklyn:sensor("propagatingSensor.list")
+            enricher.aggregating.fromMembers: true
+            enricher.aggregator.excludeBlank: true
+        - type: org.apache.brooklyn.enricher.stock.Joiner
+          brooklyn.config:
+            uniqueTag: drbd-propagatingSensor-joiner
+            enricher.sourceSensor: $brooklyn:sensor("propagatingSensor.list")
+            enricher.targetSensor: $brooklyn:sensor($brooklyn:config("propagatingSensor"))
+            enricher.joiner.quote: false
+        # DRBD node management
         - type: org.apache.brooklyn.enricher.stock.Aggregator
           brooklyn.config:
             uniqueTag: drbd-hostaddress-aggregator
@@ -585,5 +622,16 @@ brooklyn.catalog:
             enricher.sourceSensor: $brooklyn:sensor("drbd.started.list")
             enricher.targetSensor: $brooklyn:sensor("drbd.started")
             enricher.joiner.quote: false
+        - type: org.apache.brooklyn.enricher.stock.Transformer
+          brooklyn.config:
+            enricher.sourceSensor: $brooklyn:sensor("drbd.started")
+            enricher.targetSensor: $brooklyn:sensor("drbd.all.started")
+            enricher.transformation:
+             $brooklyn:object:
+               type: "com.google.guava:com.google.common.base.Functions"
+               factoryMethod.name: "forMap"
+               factoryMethod.args:
+               - "started,started" : true
+               - false
       brooklyn.policies:
       - type: org.apache.brooklyn.policy.ha.ServiceReplacer

--- a/drbd.mysql-example.bom
+++ b/drbd.mysql-example.bom
@@ -65,9 +65,10 @@ brooklyn.catalog:
         brooklyn.enrichers:
           - type: org.apache.brooklyn.enricher.stock.Propagator
             brooklyn.config:
+              enricher.suppressDuplicates: true
               producer: $brooklyn:entity("drbd-pair")
               propagating:
-              - $brooklyn:sensor("drbd.all.started")
+              - drbd.all.started
         brooklyn.config:
           cluster.initial.size: 2
           dynamiccluster.memberspec:
@@ -78,11 +79,13 @@ brooklyn.catalog:
               brooklyn.enrichers:
               - type: org.apache.brooklyn.enricher.stock.Propagator
                 brooklyn.config:
+                  enricher.suppressDuplicates: true
                   producer: $brooklyn:entity("drbd-pair")
                   propagating:
-                    - $brooklyn:sensor("datastore.url")
+                    - datastore.url
               - type: org.apache.brooklyn.enricher.stock.Transformer
                 brooklyn.config:
+                  enricher.suppressDuplicates: true
                   enricher.triggerSensors:
                     - $brooklyn:sensor("datastore.url")
                   enricher.targetSensor: $brooklyn:sensor("additionalJavaParams")

--- a/drbd.mysql-example.bom
+++ b/drbd.mysql-example.bom
@@ -93,21 +93,46 @@ brooklyn.catalog:
                     - "visitors"
                     - "brooklyn"
                     - "br00k11n"
+              brooklyn.initializers:
+              - type: org.apache.brooklyn.core.effector.ssh.SshCommandEffector      
+                brooklyn.config:
+                  name: redeployDB
+                  description: |
+                    Redeploys the application
+                  shell.env:
+                    additionalJavaParams: $brooklyn:attributeWhenReady("additionalJavaParams")
+                    #serviceIsUp: $brooklyn:attributeWhenReady("service.isUp")
+                  command: |
+                    cd ~
+                    if [ ! -f "jetty-runner.pid" ]; then
+                      echo "Not yet started"
+                      exit 0;
+                    fi
+                    CURR_PARAMS=`cat ~/params.txt`
+                    if [ "${additionalJavaParams}" == "" ] || [ "${additionalJavaParams}" == "${CURR_PARAMS}" ]; then
+                      exit 0;
+                    fi
+                    (
+                    flock -x -w 10 200 || exit 0
+                    echo 1
+                    if [ -n "${additionalJavaParams}" ]; then
+                      echo ${additionalJavaParams} > ~/params.txt
+                    fi
+                    echo 2
+                    kill `cat ~/jetty-runner.pid` || true
+                    echo 3
+                    nohup java `cat ~/params.txt` -jar ~/jetty-runner.jar ~/run.war --port 8080 2>&1 & echo $! > ~/jetty-runner.pid
+                    echo 4
+                    ) 200>/tmp/.drbdlockfile
+                    rm /tmp/.drbdlockfile || true
+                  
               brooklyn.policies:
-              - type: org.apache.brooklyn.policy.InvokeEffectorOnCollectionSensorChange
+              - type: org.apache.brooklyn.policy.InvokeEffectorOnSensorChange
                 brooklyn.config:
                   sensor: $brooklyn:sensor("additionalJavaParams")
-                  onAdded: redeploy
-                  onRemoved: redeploy
-                  parameterName: additionalJavaParams
+                  effector: redeployDB
               brooklyn.config:
                 latch.install: $brooklyn:entity("webapp").attributeWhenReady("drbd.all.started")
                 war.url: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.9.0/brooklyn-example-hello-world-sql-webapp-0.9.0.war
-                additional.java.params: 
-                  $brooklyn:formatString:
-                    - "-Dbrooklyn.example.db.url=jdbc:%s%s?user=%s&password=%s"
-                    - $brooklyn:entity("drbd-pair").attributeWhenReady("datastore.url")
-                    - "visitors"
-                    - "brooklyn"
-                    - "br00k11n"        
+                additional.java.params: $brooklyn:attributeWhenReady("additionalJavaParams")   
           

--- a/drbd.mysql-example.bom
+++ b/drbd.mysql-example.bom
@@ -1,0 +1,113 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+brooklyn.catalog:
+  version: "1.0.0-SNAPSHOT" # BROOKLYN_DRBD_VERSION
+  description: |
+    This is an example DRBD database application. MySQL instances are mirrored on DRBD with Jetty runners pointing at the primary
+  publish:
+    license_code: Apache-2.0
+  items: 
+  - id: example-drbd-mysql
+    item: 
+      type: org.apache.brooklyn.entity.database.mysql.MySqlNode
+      brooklyn.config:
+        mysql.password: s0m3rand0mp4ss
+        latch.install: $brooklyn:parent().parent().attributeWhenReady("service.isUp")
+        # customize will set the data directory to the drbd one, so block until we are primary
+        latch.customize: $brooklyn:parent().sibling("drbd-node").attributeWhenReady("is.active.primary")
+        mysql.datadir: /mnt
+          
+  - id: initial-example-drbd-mysql
+    item: 
+      type: example-drbd-mysql 
+      id: initial-db
+      brooklyn.config:
+        datastore.creation.script.url: https://github.com/apache/brooklyn-library/raw/master/examples/simple-web-cluster/src/main/resources/visitors-creation-script.sql
+             
+  - id: drbd-database
+    name: DRBD Database
+    itemType: template
+    iconUrl: "https://s3.eu-central-1.amazonaws.com/misc-csft/drbd.jpg"
+    license: Apache-2.0
+    item:
+      booklyn.config:
+        defaultDisplayName: DRBD Database
+      services:
+      - type: drbd-pair
+        brooklyn.config:
+          propagatingSensor: $brooklyn:sensor("datastore.url")
+          nodeSpecification: 
+            $brooklyn:entitySpec:
+              - type: example-drbd-mysql
+          initialNodeSpecification:
+            $brooklyn:entitySpec:
+              - type: initial-example-drbd-mysql
+              
+      - type: cluster
+        id: webapp
+        name: "Webapp"
+        brooklyn.enrichers:
+          - type: org.apache.brooklyn.enricher.stock.Propagator
+            brooklyn.config:
+              producer: $brooklyn:entity("drbd-pair")
+              propagating:
+              - $brooklyn:sensor("drbd.all.started")
+        brooklyn.config:
+          cluster.initial.size: 2
+          dynamiccluster.memberspec:
+            $brooklyn:entitySpec:
+              type: jetty-runner
+              id: jetty-runner
+              name: Jetty Runner App
+              brooklyn.enrichers:
+              - type: org.apache.brooklyn.enricher.stock.Propagator
+                brooklyn.config:
+                  producer: $brooklyn:entity("drbd-pair")
+                  propagating:
+                    - $brooklyn:sensor("datastore.url")
+              - type: org.apache.brooklyn.enricher.stock.Transformer
+                brooklyn.config:
+                  enricher.triggerSensors:
+                    - $brooklyn:sensor("datastore.url")
+                  enricher.targetSensor: $brooklyn:sensor("additionalJavaParams")
+                  enricher.targetValue:
+                    $brooklyn:formatString:
+                    - "-Dbrooklyn.example.db.url=jdbc:%s%s?user=%s&password=%s"
+                    - $brooklyn:attributeWhenReady("datastore.url")
+                    - "visitors"
+                    - "brooklyn"
+                    - "br00k11n"
+              brooklyn.policies:
+              - type: org.apache.brooklyn.policy.InvokeEffectorOnCollectionSensorChange
+                brooklyn.config:
+                  sensor: $brooklyn:sensor("additionalJavaParams")
+                  onAdded: redeploy
+                  onRemoved: redeploy
+                  parameterName: additionalJavaParams
+              brooklyn.config:
+                latch.install: $brooklyn:entity("webapp").attributeWhenReady("drbd.all.started")
+                war.url: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.9.0/brooklyn-example-hello-world-sql-webapp-0.9.0.war
+                additional.java.params: 
+                  $brooklyn:formatString:
+                    - "-Dbrooklyn.example.db.url=jdbc:%s%s?user=%s&password=%s"
+                    - $brooklyn:entity("drbd-pair").attributeWhenReady("datastore.url")
+                    - "visitors"
+                    - "brooklyn"
+                    - "br00k11n"        
+          

--- a/drbd.tomcat-example.bom
+++ b/drbd.tomcat-example.bom
@@ -35,8 +35,8 @@ brooklyn.catalog:
           producer: $brooklyn:child("tomcat")
           propagating:
           - $brooklyn:sensor("main.uri")
+          
       brooklyn.children:
-                             
       - type: org.apache.brooklyn.entity.database.mysql.MySqlNode
         id: db
         brooklyn.config:
@@ -77,8 +77,7 @@ brooklyn.catalog:
       services:
       - type: drbd-pair
         brooklyn.config:
-          propagatingList:
-          - $brooklyn:sensor("main.uri")
+          propagatingSensor: $brooklyn:sensor("main.uri")
           nodeSpecification: 
             $brooklyn:entitySpec:
               - type: example-app


### PR DESCRIPTION
Adds a database and [Jetty Runner](https://github.com/brooklyncentral/brooklyn-jetty-runner) example which restarts Jetty Runner with the primary database URL whenever the primary DRBD node changes.